### PR TITLE
Add option to force flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Feel free to modify the source code and use as desired.  It was compiled using V
 
 ```
 Usage:
-  COMpipe [-b <baud rate>] [-d <data bits>] [-r <parity>] [-s <stop bits>] -c <COM port name> -p <pipe name>
+  COMpipe [-b <baud rate>] [-d <data bits>] [-r <parity>] [-s <stop bits>] [-f] -c <COM port name> -p <pipe name>
 
 Examples:
   COMpipe -c \\.\COM8 -p \\.\pipe\MyLittlePipe
@@ -25,6 +25,7 @@ Notes:
       Options are: 0=1, 1=1.5, 2=2
   7. Hardware signals like RTS/CTS, DTR/DSR, DCD, and RI are not supported.
       This is because the named pipe created by the VM does not support these signals.
+  8. -f is to force stdout flushing. This is useful when piping output to another process.
 ```
 
 ## Changelog

--- a/main.cpp
+++ b/main.cpp
@@ -268,6 +268,15 @@ int main(int argc, char **argv)
     char error[400];
     DWORD gle = 0;
 
+    // review command line parameters for pipe and COM port names
+    InputParser input(argc, argv);
+
+    bool force_flush = input.cmdOptionExists("--force-stdout-flush");
+    if (force_flush)
+    {
+        setvbuf(stdout, nullptr, _IONBF, 0);
+    }
+
     printf("COMpipe 0.3\n");
     printf("https://github.com/tdhoward/COMpipe\n\n");
 
@@ -275,7 +284,7 @@ int main(int argc, char **argv)
     if(argc < 2)
     {
         printf("Usage:\n");
-        printf("  COMpipe [-b <baud rate>] [-d <data bits>] [-r <parity>] [-s <stop bits>] -c <COM port name> -p <pipe name>\n\n");
+        printf("  COMpipe [-b <baud rate>] [-d <data bits>] [-r <parity>] [-s <stop bits>] [--force-stdout-flush] -c <COM port name> -p <pipe name>\n\n");
         printf("Examples:\n");
         printf("  COMpipe -c \\\\.\\COM8 -p \\\\.\\pipe\\MyLittlePipe\n");
         printf("  COMpipe -b 19200 -c \\\\.\\COM8 -p \\\\.\\pipe\\MyLittlePipe\n\n");
@@ -294,9 +303,6 @@ int main(int argc, char **argv)
     }
 
     printf("Press Q to quit.\n");
-
-    // review command line parameters for pipe and COM port names
-    InputParser input(argc, argv);
 
     const string &pipe_name = input.getCmdOption("-p");
     if (pipe_name.empty())

--- a/main.cpp
+++ b/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
     // review command line parameters for pipe and COM port names
     InputParser input(argc, argv);
 
-    bool force_flush = input.cmdOptionExists("--force-stdout-flush");
+    bool force_flush = input.cmdOptionExists("-f");
     if (force_flush)
     {
         setvbuf(stdout, nullptr, _IONBF, 0);
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
     if(argc < 2)
     {
         printf("Usage:\n");
-        printf("  COMpipe [-b <baud rate>] [-d <data bits>] [-r <parity>] [-s <stop bits>] [--force-stdout-flush] -c <COM port name> -p <pipe name>\n\n");
+        printf("  COMpipe [-b <baud rate>] [-d <data bits>] [-r <parity>] [-s <stop bits>] [-f] -c <COM port name> -p <pipe name>\n\n");
         printf("Examples:\n");
         printf("  COMpipe -c \\\\.\\COM8 -p \\\\.\\pipe\\MyLittlePipe\n");
         printf("  COMpipe -b 19200 -c \\\\.\\COM8 -p \\\\.\\pipe\\MyLittlePipe\n\n");
@@ -299,6 +299,7 @@ int main(int argc, char **argv)
         printf("      Options are: 0=1, 1=1.5, 2=2\n");
         printf("  7. Hardware signals like RTS/CTS, DTR/DSR, DCD, and RI are not supported.\n");
         printf("      This is because the named pipe created by the VM does not support these signals.\n\n");
+        printf("  8. -f is to force stdout flushing. This is useful when piping output to another process.");
         return 0;
     }
 


### PR DESCRIPTION
-f option added to force flushing stdout.  This is useful when the process is spawned as a child process or stdout piped somewhere other than console.